### PR TITLE
#38: Removed exasol-test-setup-abstraction as compile dependency

### DIFF
--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [0.6.3](changes_0.6.3.md)
 * [0.6.2](changes_0.6.2.md)
 * [0.6.1](changes_0.6.1.md)
 * [0.6.0](changes_0.6.0.md)

--- a/doc/changes/changes_0.6.3.md
+++ b/doc/changes/changes_0.6.3.md
@@ -1,0 +1,24 @@
+# udf-debugging-java 0.6.3, released 2022-??-??
+
+Code name:
+
+## Summary
+
+In this release we removed the exasol-test-setup-abstraction from the compile dependencies. Now it's declared as `provided`. By that, it's no longer pulled as transitive dependency into other projects.
+
+## Bug Fixes
+
+* #38: Removed exasol-test-setup-abstraction as compile dependency
+
+## Dependency Updates
+
+### Compile Dependency Updates
+
+* Removed `com.exasol:exasol-test-setup-abstraction-java:0.3.2`
+
+### Test Dependency Updates
+
+* Updated `com.exasol:exasol-testcontainers:6.1.1` to `6.1.2`
+* Updated `com.exasol:test-db-builder-java:3.3.2` to `3.3.3`
+* Updated `org.mockito:mockito-junit-jupiter:4.5.1` to `4.6.1`
+* Updated `org.testcontainers:junit-jupiter:1.17.1` to `1.17.2`

--- a/doc/changes/changes_0.6.3.md
+++ b/doc/changes/changes_0.6.3.md
@@ -1,6 +1,6 @@
-# udf-debugging-java 0.6.3, released 2022-??-??
+# udf-debugging-java 0.6.3, released 2022-06-24
 
-Code name:
+Code name: Removed ETSA dependency
 
 ## Summary
 

--- a/pk_generated_parent.pom
+++ b/pk_generated_parent.pom
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>udf-debugging-java-generated-parent</artifactId>
-    <version>0.6.2</version>
+    <version>0.6.3</version>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>udf-debugging-java</artifactId>
-    <version>0.6.2</version>
+    <version>0.6.3</version>
     <name>udf-debugging-java</name>
     <description>Utilities for debugging, profiling and code coverage measure for UDFs.</description>
     <url>https://github.com/exasol/udf-debugging-java/</url>
@@ -81,6 +81,7 @@
             <groupId>com.exasol</groupId>
             <artifactId>exasol-test-setup-abstraction-java</artifactId>
             <version>0.3.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -108,7 +109,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.5.1</version>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -121,19 +122,19 @@
         <dependency>
             <groupId>com.exasol</groupId>
             <artifactId>exasol-testcontainers</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.17.1</version>
+            <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.exasol</groupId>
             <artifactId>test-db-builder-java</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -257,7 +258,7 @@
     <parent>
         <artifactId>udf-debugging-java-generated-parent</artifactId>
         <groupId>com.exasol</groupId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
         <relativePath>pk_generated_parent.pom</relativePath>
     </parent>
 </project>


### PR DESCRIPTION
Closes #38 